### PR TITLE
Adjust health to percentage of max health in all cases

### DIFF
--- a/src/main/java/org/terasology/physicalstats/system/PhysicalStatsSystem.java
+++ b/src/main/java/org/terasology/physicalstats/system/PhysicalStatsSystem.java
@@ -43,6 +43,11 @@ public class PhysicalStatsSystem extends BaseComponentSystem {
      */
     private static final Logger logger = LoggerFactory.getLogger(PhysicalStatsSystem.class);
 
+    /**
+     * The value to multiply the constitution stat by for the maximum health. 10 by default.
+     */
+    public static int constitutionMultiplier = 10;
+
     @In
     private EntityManager entityManager;
 
@@ -76,10 +81,11 @@ public class PhysicalStatsSystem extends BaseComponentSystem {
      */
     public boolean updateHealth(EntityRef e, HealthComponent h, PhysicalStatsComponent p)
     {
-        if (h.maxHealth != p.constitution * 10) {
+        int newHealth = p.constitution * constitutionMultiplier;
+        if (h.maxHealth != newHealth) {
             float hP = (float) h.currentHealth / (float) h.maxHealth;
-            h.maxHealth = p.constitution * 10;
-            h.currentHealth = (int) Math.floor(h.maxHealth * hP);
+            h.maxHealth = newHealth;
+            h.currentHealth = (int) Math.floor(newHealth * hP);
             e.saveComponent(h);
             return true;
         }
@@ -99,10 +105,7 @@ public class PhysicalStatsSystem extends BaseComponentSystem {
         // If the player entity has a health component, make sure that the max health is equal to CON * 10, and the
         // current health is equal to the maximum.
         if (player.hasComponent(HealthComponent.class)) {
-            HealthComponent h = player.getComponent(HealthComponent.class);
-            h.maxHealth = phyStats.constitution * 10;
-            h.currentHealth = h.maxHealth;
-            player.saveComponent(h);
+            updateHealth(player, player.getComponent(HealthComponent.class), phyStats);
         }
     }
 

--- a/src/main/java/org/terasology/physicalstats/system/PhysicalStatsSystem.java
+++ b/src/main/java/org/terasology/physicalstats/system/PhysicalStatsSystem.java
@@ -81,11 +81,11 @@ public class PhysicalStatsSystem extends BaseComponentSystem {
      */
     public boolean updateHealth(EntityRef e, HealthComponent h, PhysicalStatsComponent p)
     {
-        int newHealth = p.constitution * constitutionMultiplier;
-        if (h.maxHealth != newHealth) {
-            float hP = (float) h.currentHealth / (float) h.maxHealth;
-            h.maxHealth = newHealth;
-            h.currentHealth = (int) Math.floor(newHealth * hP);
+        int newMaxHealth = p.constitution * constitutionMultiplier;
+        if (h.maxHealth != newMaxHealth) {
+            float healthPercentage = (float) h.currentHealth / (float) h.maxHealth;
+            h.maxHealth = newMaxHealth;
+            h.currentHealth = (int) Math.floor(newMaxHealth * healthPercentage);
             e.saveComponent(h);
             return true;
         }

--- a/src/main/java/org/terasology/physicalstats/system/PhysicalStatsSystem.java
+++ b/src/main/java/org/terasology/physicalstats/system/PhysicalStatsSystem.java
@@ -60,18 +60,30 @@ public class PhysicalStatsSystem extends BaseComponentSystem {
             if (clientEntity.hasComponent(HealthComponent.class)) {
                 HealthComponent h = clientEntity.getComponent(HealthComponent.class);
                 PhysicalStatsComponent p = clientEntity.getComponent(PhysicalStatsComponent.class);
-
-                // Ensure that the health is set to the appropriate percentage of the appropriate maximum health
-                if (h.maxHealth != p.constitution * 10) {
-                    float hP = (float) h.currentHealth / (float) h.maxHealth;
-                    h.maxHealth = p.constitution * 10;
-                    h.currentHealth = (int) Math.floor(h.maxHealth * hP);
-                    clientEntity.saveComponent(h);
-                }
+                updateHealth(clientEntity, h, p);
             }
         }
 
         super.initialise();
+    }
+
+    /**
+     * Sets the health and maximum health values as components of the PhysicalStats constitution stat.
+     * @param e The entity (i.e. player) to update
+     * @param h The health stats of the player
+     * @param p The physical stats of the player
+     * @return True if changed, false if unchanged
+     */
+    public boolean updateHealth(EntityRef e, HealthComponent h, PhysicalStatsComponent p)
+    {
+        if (h.maxHealth != p.constitution * 10) {
+            float hP = (float) h.currentHealth / (float) h.maxHealth;
+            h.maxHealth = p.constitution * 10;
+            h.currentHealth = (int) Math.floor(h.maxHealth * hP);
+            e.saveComponent(h);
+            return true;
+        }
+        return false;
     }
 
     /**
@@ -108,11 +120,7 @@ public class PhysicalStatsSystem extends BaseComponentSystem {
         // current health is above the maximum health, set the current equal to the max.
         if (player.hasComponent(HealthComponent.class)) {
             HealthComponent h = player.getComponent(HealthComponent.class);
-
-            float hP = (float) h.currentHealth / (float) h.maxHealth;
-            h.maxHealth = phyStats.constitution * 10;
-            h.currentHealth = (int) Math.floor(h.maxHealth * hP);
-            player.saveComponent(h);
+            updateHealth(player, h, phyStats);
         }
     }
 

--- a/src/main/java/org/terasology/physicalstats/system/PhysicalStatsSystem.java
+++ b/src/main/java/org/terasology/physicalstats/system/PhysicalStatsSystem.java
@@ -59,12 +59,13 @@ public class PhysicalStatsSystem extends BaseComponentSystem {
             // For every entity that has a health component, set their max health equal to CON * 10.
             if (clientEntity.hasComponent(HealthComponent.class)) {
                 HealthComponent h = clientEntity.getComponent(HealthComponent.class);
+                PhysicalStatsComponent p = clientEntity.getComponent(PhysicalStatsComponent.class);
 
-                // This check is in place so that the current health isn't reset to max health when reloading a game
-                // save. It should only be done when the two are already equal.
-                if (h.currentHealth == h.maxHealth) {
-                    h.maxHealth = clientEntity.getComponent(PhysicalStatsComponent.class).constitution * 10;
-                    h.currentHealth = h.maxHealth;
+                // Ensure that the health is set to the appropriate percentage of the appropriate maximum health
+                if (h.maxHealth != p.constitution * 10) {
+                    float hP = (float) h.currentHealth / (float) h.maxHealth;
+                    h.maxHealth = p.constitution * 10;
+                    h.currentHealth = (int) Math.floor(h.maxHealth * hP);
                     clientEntity.saveComponent(h);
                 }
             }
@@ -107,11 +108,10 @@ public class PhysicalStatsSystem extends BaseComponentSystem {
         // current health is above the maximum health, set the current equal to the max.
         if (player.hasComponent(HealthComponent.class)) {
             HealthComponent h = player.getComponent(HealthComponent.class);
-            h.maxHealth = phyStats.constitution * 10;
 
-            if (h.currentHealth > h.maxHealth) {
-                h.currentHealth = h.maxHealth;
-            }
+            float hP = (float) h.currentHealth / (float) h.maxHealth;
+            h.maxHealth = phyStats.constitution * 10;
+            h.currentHealth = (int) Math.floor(h.maxHealth * hP);
             player.saveComponent(h);
         }
     }


### PR DESCRIPTION
If the entity's health does not equal the entity's old maximum health, it should be calculated to a rounded percentage of the adjusted maximum health rather than remaining at its current value.